### PR TITLE
Fix missing install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'htmlparsing',
         'htmlfetcher',
         'flask',
-        'click'
+        'click',
+        'cssselect'
     ],
     license='Apache 2.0',
     packages=find_packages(),


### PR DESCRIPTION
```cssselect``` PYPI package was not part of the ```install_requirements``` list in ```setup.py```